### PR TITLE
Fix build error

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,6 @@
     <input type=button value="Clear map" onClick="window.location.reload()">
     <br>
     <div id="map" class="map"><div id="popup"></div></div>
-    <script src="index.js"></script>
+    <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "cb-mapui",
   "dependencies": {
+    "buffer":"^6.0.3",
     "csv-parser": "^3.0.0",
+    "http":"^0.0.1-security",
     "ol": "^6.6.1"
   },
   "devDependencies": {
@@ -14,7 +16,6 @@
   },
   "description": "A MapUI Client for CB-Tumblebug (display multi-cloud infra service)",
   "version": "0.4.1",
-  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cloud-barista/cb-mapui.git"


### PR DESCRIPTION

resolves following build error

```
son@son:~/dev/cb-mapui$ npm run build

> cb-mapui@0.4.1 build /home/son/dev/cb-mapui
> parcel build --public-url . index.html

🚨 Build failed.

@parcel/transformer-js: Browser scripts cannot have imports or exports.

  /home/son/dev/cb-mapui/index.js:1:1
  > 1 | import 'ol/ol.css';
  >   | ^^^^^^^^^^^^^^^^^^^
    2 | import Map from 'ol/Map';
    3 | import View from 'ol/View';
  
  /home/son/dev/cb-mapui/index.html:6:5
    5 |     <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
  > 6 |     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,U
  >   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The environment was originally created here
    7 |     <script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
    8 |     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">

  💡 Add the type="module" attribute to the <script> tag.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! cb-mapui@0.4.1 build: `parcel build --public-url . index.html`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the cb-mapui@0.4.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/son/.npm/_logs/2021-09-02T02_04_29_699Z-debug.log
```