### PR TITLE
Remove type=module from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
   <div id="map" class="map">
     <div id="popup"></div>
   </div>
-  <script type="module" src="index.js"></script>
+  <script src="index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION

- container 구동 시, image resource 불러오지 못하는 이슈 해결을 위한 type="module" 항목 제거
- 주의: 환경에 따라 빌드 오류를 일으킬 수 있음 (향후 개선 필요)

```
> cb-mapui@0.4.1 build
> parcel build --public-url . index.html

🚨 Build failed.

@parcel/transformer-js: Browser scripts cannot have imports or exports.

  /home/shson/go/src/github.com/cloud-barista/cb-mapui/index.js:1:1
  > 1 | import 'ol/ol.css';
  >   | ^^^^^^^^^^^^^^^^^^^
    2 | import Map from 'ol/Map';
    3 | import View from 'ol/View';
  
  /home/shson/go/src/github.com/cloud-barista/cb-mapui/index.html:7:3
     6 |   <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
  >  7 |   <script
  >    |   ^^^^^^^
  >  8 |     src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
  >    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The environment was originally created here
     9 |   <script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
    10 |   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">

  💡 Add the type="module" attribute to the <script> tag.
```