### PR TITLE
Enhance createMCIS feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,6 @@
   <script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-  <script>
-    function clearInputForms(action) {
-      document.getElementById('latitude').value = '';
-      document.getElementById('longitude').value = '';
-      document.getElementById('recommendedSpec').value = '';
-    }
-
-    window.onload = function() {
-      clearInputForms();
-    }
-  </script>
   <style>
     .map {
       width: 100%;
@@ -47,9 +36,12 @@
         <td> <input type=text id=namespace name=namespace value="ns01" style="text-align:center; width:120px"></td>
         <td> &nbsp;&nbsp;TB MCIS ID:&nbsp;&nbsp;</td>
         <!-- <td> <input type="text" id="mcisid" name="mcisid" value="mcis01" style="text-align:center; width:120px"> </td> -->
-        <td> <select id="mcisid" name="mcisid">
-          <option value="mcis01">mcis01</option>
-        </select> </td>
+        <td>
+          <select id="mcisid" name="mcisid">
+          <!-- <option value="mcis01">mcis01</option> -->
+          </select> 
+          <input type=button value="Reload" onClick="updateMcisList();" style="text-align:center; width:120px">
+        </td>
         <td> </td>
         <td> </td>
         <td> &nbsp;&nbsp;Refresh interval:&nbsp;&nbsp;</td>
@@ -64,18 +56,22 @@
   <input type=button value="Resume" onClick="controlMCIS('resume');" style="text-align:center; width:120px">
   <input type=button value="Reboot" onClick="controlMCIS('reboot');" style="text-align:center; width:120px">
   <input type=button value="Terminate" onClick="controlMCIS('terminate');" style="text-align:center; width:120px">
+  <input type=button value="Delete" onClick="deleteMCIS();" style="text-align:center; width:120px">
   &nbsp;&nbsp;View:&nbsp;&nbsp;
   <input type=button value="Clear map" onClick="window.location.reload()" style="text-align:center; width:120px">
   <br>
   <br>
-  <input type=button value="Clear input forms" onClick="clearInputForms();" style="text-align:center; width:180px">
+  <input type=button value="Clear all" onClick="clearCoordinates();" style="text-align:center; width:180px">
   <br>
+  <!-- 
   Latitude: <input type=text id=latitude name=latitude  value="" style="text-align:center; width:120px"> 
   Longitude: <input type=text id=longitude name=longitude  value="" style="text-align:center; width:120px"> 
   <input type=button value="Get Recommended Spec" onClick="getRecommendedSpec();" style="text-align:center; width:180px">
   <br>
-  Recommended spec: <input type=text id=recommendedSpec name=recommendedSpec  value="" style="text-align:center; width:180px"> 
-  <input type=button value="Create MCIS dynamically" onClick="createMcisDynamically();" style="text-align:center; width:180px">
+  Recommended spec: <input type=text id=recommendedSpec name=recommendedSpec  value="" style="text-align:center; width:180px">
+  -->
+  <div id="latLonInputPairArea"></div>
+  <input type=button value="Create MCIS" onClick="createMcis();" style="text-align:center; width:180px">
 
   <div id="map" class="map">
     <div id="popup"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cb-mapui",
-  "version": "0.4.2",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build --public-url . index.html"
   },
   "description": "A MapUI Client for CB-Tumblebug (display multi-cloud infra service)",
-  "version": "0.4.2",
+  "version": "0.4.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cloud-barista/cb-mapui.git"


### PR DESCRIPTION
- MCIS ID 드랍다운 메뉴에서 디폴트 항목 (`mcis01`) 삭제
- MCIS ID 드랍다운 메뉴를 Reload 하는 버튼 추가
  - 기존에는 Map refresh interval 마다 Map refresh 될 때 MCIS ID 드랍다운 메뉴도 함께 업데이트 하였으나,
    함께 업데이트 하지 않고 Reload 버튼으로 업데이트 하도록 함
- MCIS Control 부분에 Delete 버튼 추가
- Enhance createMCIS feature
  - 지도를 클릭하면 클릭 지점의 좌표가 표시되고, 곧바로 TB의 recommendSpec API를 호출하여 recommendSpec 표시
  - 사용자가 지도 클릭을 반복하여, 생성할 VM spec의 목록을 구성
  - VM spec의 목록을 만들던 중 "Clear all" 버튼을 클릭하면 VM spec의 목록을 초기화
  - "Create MCIS" 버튼을 눌러 실제 MCIS 생성

![image](https://user-images.githubusercontent.com/46767780/142553670-9ca2b6ef-207f-4b72-ae59-645c88212a43.png)
