### PR TITLE
Automate get CB-TB host from the client given URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -2456,6 +2456,12 @@ window.statusApp = statusApp;
 
 
 window.onload = function() {
+  // Get host address and update text field
+  var tbServerAp = window.location.host;
+  var strArray = tbServerAp.split(':');
+  console.log('Host address: '+ strArray[0]);
+  document.getElementById("hostname").value = strArray[0];
+
   updateMcisList();
 }
 

--- a/index.js
+++ b/index.js
@@ -1115,7 +1115,7 @@ function getMcis() {
       username: `${username}`,
       password: `${password}`
     },
-    timeout: 30000
+    timeout: 60000
   })
   .then((res)=>{
       document.getElementById("hostname").style.color = "#000000";
@@ -2463,6 +2463,7 @@ window.onload = function() {
   document.getElementById("hostname").value = strArray[0];
 
   updateMcisList();
+  console.log(getMcis());
 }
 
 
@@ -2558,11 +2559,11 @@ function drawMCIS(event) {
         scale: (changeSizeByName(mcisName[i]+mcisStatus[i]) + 0.8 ),
         offsetY: 80,
         stroke: new Stroke({
-          color: 'white',
+          color: [255, 255, 255, 1], //white
           width: 1
         }),
         fill: new Fill({
-          color: 'black' //changeColorStatus(mcisStatus[i])
+          color: [0, 0, 0, 1] //black //changeColorStatus(mcisStatus[i])
         })
       }),
     });


### PR DESCRIPTION
어짜피 CORS에 걸려서,

URL의 HOST와 TB HOST 입력값이 달라도 소용이 없으므로

앱 실행시, URL의 HOST를 TB HOST로 자동 입력하여, 사용자의 입력 편의 향상.

(마이너 수정: Change timeout and color for text)