### PR TITLE
Move devDependencies to prod to fix docker err

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,32 @@
 {
   "name": "cb-mapui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cb-mapui",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.0",
         "buffer": "^6.0.3",
         "csv-parser": "^3.0.0",
+        "events": "^3.3.0",
         "http": "^0.0.1-security",
         "jquery": "^3.7.1",
         "json-formatter-js": "^2.3.4",
         "ol": "^8.1.0",
         "parcel": "^2.10.1",
-        "stream-http": "^3.2.0",
-        "sweetalert2": "^11.4.14"
-      },
-      "devDependencies": {
-        "events": "^3.3.0",
         "process": "^0.11.10",
         "punycode": "^1.4.1",
         "querystring-es3": "^0.2.1",
         "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "sweetalert2": "^11.4.14",
         "url": "^0.11.0"
-      }
+      },
+      "devDependencies": {}
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -2516,7 +2515,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -3355,7 +3353,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -3373,15 +3370,13 @@
     "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -3390,7 +3385,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -3538,7 +3532,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "dev": true,
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -3684,7 +3677,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -3693,8 +3685,7 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -5242,8 +5233,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -5759,8 +5749,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "protocol-buffers-schema": {
       "version": "3.6.0",
@@ -5775,20 +5764,17 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-      "dev": true
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "quick-lru": {
       "version": "6.1.2",
@@ -5885,7 +5871,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "dev": true,
       "requires": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -5979,7 +5964,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -5988,8 +5972,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "ol": "^8.1.0",
     "parcel": "^2.10.1",
     "stream-http": "^3.2.0",
-    "sweetalert2": "^11.4.14"
-  },
-  "devDependencies": {
+    "sweetalert2": "^11.4.14",
     "events": "^3.3.0",
     "process": "^0.11.10",
-    "punycode": "^1.4.1",
-    "querystring-es3": "^0.2.1",
+    "url": "^0.11.0",
     "stream-browserify": "^3.0.0",
-    "url": "^0.11.0"
+    "querystring-es3": "^0.2.1",
+    "punycode": "^1.4.1"
+  },
+  "devDependencies": {
   },
   "scripts": {
     "start": "parcel -p 1324 index.html",


### PR DESCRIPTION
devDependencies에 포함된 pkg 들이 runtime에서 사용되는 경우가 있는데,

dockerfile에서 production용 prune 을 하게되면서, devDependencies에 포함된 pkg들을 삭제하게 되고, 

이에 따라 빌드 및 런타임 에러가 발생한 것으로 추정.

이를 수정 및 테스트해보기 위한 PR.