### PR TITLE
Adapt to cb-tumblebug K8s model generalization: update request body structure and response field names

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1669,9 +1669,9 @@ function updateProviderRegionChart() {
       } else if (cluster.location && cluster.location.cloudType) {
         provider = cluster.location.cloudType.toLowerCase(); // Normalize to lowercase
         console.log('Provider from location.cloudType:', provider);
-      } else if (cluster.k8sNodeGroupList && cluster.k8sNodeGroupList.length > 0 && cluster.k8sNodeGroupList[0].connectionConfig && cluster.k8sNodeGroupList[0].connectionConfig.providerName) {
-        provider = cluster.k8sNodeGroupList[0].connectionConfig.providerName.toLowerCase(); // Normalize to lowercase
-        console.log('Provider from k8sNodeGroupList[0].connectionConfig.providerName:', provider);
+      } else if (cluster.nodeGroups && cluster.nodeGroups.length > 0 && cluster.nodeGroups[0].connectionConfig && cluster.nodeGroups[0].connectionConfig.providerName) {
+        provider = cluster.nodeGroups[0].connectionConfig.providerName.toLowerCase(); // Normalize to lowercase
+        console.log('Provider from nodeGroups[0].connectionConfig.providerName:', provider);
       }
       
       // Extract region information from cluster
@@ -1700,9 +1700,9 @@ function updateProviderRegionChart() {
       }
       
       // Count nodes from all node groups in this cluster
-      if (cluster.k8sNodeGroupList && cluster.k8sNodeGroupList.length > 0) {
-        console.log('Processing node groups:', cluster.k8sNodeGroupList);
-        cluster.k8sNodeGroupList.forEach(nodeGroup => {
+      if (cluster.nodeGroups && cluster.nodeGroups.length > 0) {
+        console.log('Processing node groups:', cluster.nodeGroups);
+        cluster.nodeGroups.forEach(nodeGroup => {
           console.log('Processing NodeGroup:', nodeGroup.name || nodeGroup.id);
           console.log('NodeGroup data:', nodeGroup);
           
@@ -1876,8 +1876,8 @@ function updateK8sCharts() {
       }
       
       // Process node groups
-      if (cluster.k8sNodeGroupList && cluster.k8sNodeGroupList.length > 0) {
-        cluster.k8sNodeGroupList.forEach(nodeGroup => {
+      if (cluster.nodeGroups && cluster.nodeGroups.length > 0) {
+        cluster.nodeGroups.forEach(nodeGroup => {
           console.log('Processing nodeGroup:', nodeGroup.name || nodeGroup.id, 'status:', nodeGroup.status);
           
           // Count node groups by status (use cluster status if nodeGroup status not available)
@@ -2988,11 +2988,11 @@ function updateK8sClusterTable() {
     // Count total nodes in all node groups
     let totalNodes = 0;
     let nodeGroupsInfo = '';
-    if (cluster.k8sNodeGroupList && cluster.k8sNodeGroupList.length > 0) {
-      totalNodes = cluster.k8sNodeGroupList.reduce((sum, ng) => {
+    if (cluster.nodeGroups && cluster.nodeGroups.length > 0) {
+      totalNodes = cluster.nodeGroups.reduce((sum, ng) => {
         return sum + (ng.desiredNodeSize || ng.spiderViewK8sNodeGroupDetail?.DesiredNodeSize || 0);
       }, 0);
-      nodeGroupsInfo = `${cluster.k8sNodeGroupList.length} groups (${totalNodes} nodes)`;
+      nodeGroupsInfo = `${cluster.nodeGroups.length} groups (${totalNodes} nodes)`;
     } else {
       nodeGroupsInfo = '0 groups';
     }
@@ -3112,12 +3112,12 @@ function updateK8sNodeGroupTable() {
   k8sData.forEach(cluster => {
     console.log('Processing cluster:', cluster.id, 'Full cluster object:', cluster);
     
-    // Handle different possible node group field names - comprehensive check
-    let nodeGroups = cluster.k8sNodeGroupList || cluster.nodeGroupList || cluster.nodeGroups || cluster.NodeGroupList || cluster.K8sNodeGroupList || [];
+    // Handle different possible node group field names - comprehensive check (nodeGroups is the new primary field)
+    let nodeGroups = cluster.nodeGroups || cluster.k8sNodeGroupList || cluster.nodeGroupList || cluster.NodeGroupList || cluster.K8sNodeGroupList || [];
     console.log('Found node groups:', nodeGroups, 'Field used:', 
+      cluster.nodeGroups ? 'nodeGroups' :
       cluster.k8sNodeGroupList ? 'k8sNodeGroupList' :
       cluster.nodeGroupList ? 'nodeGroupList' :
-      cluster.nodeGroups ? 'nodeGroups' :
       cluster.NodeGroupList ? 'NodeGroupList' :
       cluster.K8sNodeGroupList ? 'K8sNodeGroupList' : 'none');
     
@@ -4122,8 +4122,8 @@ function viewNodeGroupDetails(clusterId, nodeGroupName) {
     return;
   }
   
-  // Check multiple possible field names for node group list
-  let nodeGroupList = cluster.k8sNodeGroupList || cluster.nodeGroupList || cluster.nodeGroups || cluster.NodeGroupList || cluster.K8sNodeGroupList || [];
+  // Check multiple possible field names for node group list (nodeGroups is the new primary field)
+  let nodeGroupList = cluster.nodeGroups || cluster.k8sNodeGroupList || cluster.nodeGroupList || cluster.NodeGroupList || cluster.K8sNodeGroupList || [];
   
   if (!nodeGroupList || nodeGroupList.length === 0) {
     showErrorMessage('No node groups found for this cluster');
@@ -4169,8 +4169,9 @@ function scaleNodeGroup(clusterId, nodeGroupName) {
   const cluster = k8sData.find(c => c.id === clusterId);
   let currentNodeGroup = null;
   
-  if (cluster && cluster.k8sNodeGroupList) {
-    currentNodeGroup = cluster.k8sNodeGroupList.find(ng => ng.name === nodeGroupName || ng.id === nodeGroupName);
+  if (cluster && (cluster.nodeGroups || cluster.k8sNodeGroupList)) {
+    const nodeGroupListForSearch = cluster.nodeGroups || cluster.k8sNodeGroupList;
+    currentNodeGroup = nodeGroupListForSearch.find(ng => ng.name === nodeGroupName || ng.id === nodeGroupName);
   }
   
   // Set default values from current node group if available
@@ -4326,8 +4327,9 @@ function deleteNodeGroup(nodeGroupId, clusterId = null) {
   if (!clusterId) {
     const k8sData = centralData.k8sCluster || [];
     for (const cluster of k8sData) {
-      if (cluster.k8sNodeGroupList) {
-        const foundNodeGroup = cluster.k8sNodeGroupList.find(ng => ng.id === nodeGroupId);
+      const nodeGroupListForCluster = cluster.nodeGroups || cluster.k8sNodeGroupList;
+      if (nodeGroupListForCluster) {
+        const foundNodeGroup = nodeGroupListForCluster.find(ng => ng.id === nodeGroupId);
         if (foundNodeGroup) {
           clusterId = cluster.id;
           break;
@@ -4537,9 +4539,8 @@ window.debugK8sData = function() {
       console.log(`Cluster ${index}:`, cluster);
       console.log(`  - ID: ${cluster.id}`);
       console.log(`  - Status: ${cluster.status}`);
-      console.log(`  - k8sNodeGroupList:`, cluster.k8sNodeGroupList);
-      console.log(`  - nodeGroupList:`, cluster.nodeGroupList);
-      console.log(`  - nodeGroups:`, cluster.nodeGroups);
+      console.log(`  - nodeGroups (primary):`, cluster.nodeGroups);
+      console.log(`  - k8sNodeGroupList (legacy):`, cluster.k8sNodeGroupList);
       console.log(`  - NodeGroupList:`, cluster.NodeGroupList);
       console.log(`  - K8sNodeGroupList:`, cluster.K8sNodeGroupList);
     });

--- a/index.js
+++ b/index.js
@@ -7370,20 +7370,23 @@ function createK8sCluster() {
       if (result.isConfirmed) {
         const { namePrefix } = result.value;
         
-        // Build multi-cluster request
+        // Build multi-cluster request using new nested nodeGroups structure
         const clusters = nodeGroupRequestFromSpecList.map((sg, idx) => {
-          const clusterReq = {
-            imageId: sg.imageId || "default",
-            specId: sg.specId
+          const nodeGroupReq = {
+            name: sg.name || sg.nodeGroupName || ('ng-' + (idx + 1)),
+            specId: sg.specId,
+            imageId: sg.imageId || "default"
           };
-          if (sg.rootDiskType) clusterReq.rootDiskType = sg.rootDiskType;
-          if (sg.rootDiskSize) clusterReq.rootDiskSize = sg.rootDiskSize;
-          if (sg.nodeGroupName || sg.name) clusterReq.nodeGroupName = sg.nodeGroupName || sg.name;
+          if (sg.rootDiskType) nodeGroupReq.rootDiskType = sg.rootDiskType;
+          if (sg.rootDiskSize) nodeGroupReq.rootDiskSize = parseInt(sg.rootDiskSize, 10);
+          if (sg.nodeGroupSize || sg.desiredNodeSize) nodeGroupReq.desiredNodeSize = sg.nodeGroupSize || sg.desiredNodeSize;
+          if (sg.minNodeSize) nodeGroupReq.minNodeSize = sg.minNodeSize;
+          if (sg.maxNodeSize) nodeGroupReq.maxNodeSize = sg.maxNodeSize;
+          if (sg.onAutoScaling) nodeGroupReq.onAutoScaling = sg.onAutoScaling;
+          const clusterReq = {
+            nodeGroups: [nodeGroupReq]
+          };
           if (sg.version) clusterReq.version = sg.version;
-          if (sg.nodeGroupSize || sg.desiredNodeSize) clusterReq.desiredNodeSize = sg.nodeGroupSize || sg.desiredNodeSize;
-          if (sg.minNodeSize) clusterReq.minNodeSize = sg.minNodeSize;
-          if (sg.maxNodeSize) clusterReq.maxNodeSize = sg.maxNodeSize;
-          if (sg.onAutoScaling) clusterReq.onAutoScaling = sg.onAutoScaling;
           if (sg.connectionName) clusterReq.connectionName = sg.connectionName;
           return clusterReq;
         });
@@ -7578,25 +7581,30 @@ function createK8sCluster() {
           .then(imageDesignationNeeded => {
             removeSpinnerTask(taskId);
             
-            // Create K8s cluster request body
+            // K8s 클러스터 동적 생성 요청 바디를 새로운 중첩 구조(nodeGroups)로 빌드
             const k8sClusterReq = {
-              imageId: imageDesignationNeeded ? (nodeGroup.imageId || "default") : "default",
-              specId: nodeGroup.specId,
               name: clusterName,
-              nodeGroupName: nodeGroupName
+              nodeGroups: [
+                {
+                  name: nodeGroupName,
+                  imageId: imageDesignationNeeded ? (nodeGroup.imageId || "default") : "default",
+                  specId: nodeGroup.specId
+                }
+              ]
             };
             
-            // Add version if specified
+            // 버전에 명시되어 있다면 설정
             if (k8sVersion) {
               k8sClusterReq.version = k8sVersion;
             }
             
-            // Add rootDiskType and rootDiskSize if available
+            // rootDisk 설정이 존재한다면 첫 번째 노드그룹 내에 설정 주입
             if (nodeGroup.rootDiskType) {
-              k8sClusterReq.rootDiskType = nodeGroup.rootDiskType;
+              k8sClusterReq.nodeGroups[0].rootDiskType = nodeGroup.rootDiskType;
             }
             if (nodeGroup.rootDiskSize) {
-              k8sClusterReq.rootDiskSize = nodeGroup.rootDiskSize;
+              // Go의 int 타입 바인딩 매칭을 위해 문자열을 숫자로 파싱
+              k8sClusterReq.nodeGroups[0].rootDiskSize = parseInt(nodeGroup.rootDiskSize, 10);
             }
 
             // Check if using custom version (not from available versions list)
@@ -7709,7 +7717,7 @@ function addNodeGroupToK8sCluster() {
   axios.get(listUrl, { auth: { username, password } }).then(function (response) {
     removeSpinnerTask(listTaskId);
     
-    const clusters = response.data?.cluster || response.data?.K8sClusterInfo || [];
+    const clusters = response.data?.cluster || response.data?.ClusterInfo || [];
     
     if (clusters.length === 0) {
       errorAlert("No K8s clusters found. Please create a K8s cluster first.");
@@ -22669,9 +22677,9 @@ function loadK8sClusterData() {
     
     // Update central data store - handle both response formats
     let k8sClusterData = [];
-    if (obj.K8sClusterInfo) {
-      k8sClusterData = obj.K8sClusterInfo;
-      // console.log('Using K8sClusterInfo field');
+    if (obj.ClusterInfo) {
+      k8sClusterData = obj.ClusterInfo;
+      // console.log('Using ClusterInfo field');
     } else if (obj.cluster) {
       k8sClusterData = obj.cluster;
       // console.log('Using cluster field');
@@ -24082,13 +24090,18 @@ const TEMPLATE_TYPES = [
   "clusters": [
     {
       "connectionName": "aws-ap-northeast-2",
-      "specId": "aws+ap-northeast-2+t3a.xlarge",
-      "imageId": "default",
-      "nodeGroupName": "k8sng01",
-      "desiredNodeSize": 1,
-      "minNodeSize": 1,
-      "maxNodeSize": 2,
-      "onAutoScaling": "true"
+      "version": "1.31",
+      "nodeGroups": [
+        {
+          "name": "k8sng01",
+          "specId": "aws+ap-northeast-2+t3a.xlarge",
+          "imageId": "default",
+          "desiredNodeSize": 1,
+          "minNodeSize": 1,
+          "maxNodeSize": 2,
+          "onAutoScaling": "true"
+        }
+      ]
     }
   ]
 }`
@@ -24950,17 +24963,19 @@ async function loadTemplateToK8sConfig(namespace, templateId) {
   // Populate nodeGroupRequestFromSpecList from k8s cluster configs
   const specFetches = multiReq.clusters.map(function(cluster, idx) {
     var nodeConfig = $.extend({}, createInfraReqVmTmplt);
-    nodeConfig.name          = cluster.nodeGroupName || ('ng-' + (idx + 1));
-    nodeConfig.specId        = cluster.specId        || '';
-    nodeConfig.imageId       = cluster.imageId       || 'default';
-    nodeConfig.rootDiskType  = cluster.rootDiskType  || 'default';
-    nodeConfig.rootDiskSize  = cluster.rootDiskSize  || 0;
-    nodeConfig.nodeGroupSize = cluster.desiredNodeSize || 1;
+    // Support new nested nodeGroups structure (ClusterDynamicReq) as well as legacy flat structure
+    const firstNodeGroup = (cluster.nodeGroups && cluster.nodeGroups[0]) || cluster;
+    nodeConfig.name          = firstNodeGroup.name || cluster.nodeGroupName || ('ng-' + (idx + 1));
+    nodeConfig.specId        = firstNodeGroup.specId        || cluster.specId || '';
+    nodeConfig.imageId       = firstNodeGroup.imageId       || cluster.imageId || 'default';
+    nodeConfig.rootDiskType  = firstNodeGroup.rootDiskType  || cluster.rootDiskType || 'default';
+    nodeConfig.rootDiskSize  = firstNodeGroup.rootDiskSize  || cluster.rootDiskSize || 0;
+    nodeConfig.nodeGroupSize = firstNodeGroup.desiredNodeSize || cluster.desiredNodeSize || 1;
     nodeConfig.connectionName = cluster.connectionName || '';
     // K8s-specific fields stored for createK8sCluster() to pick up
-    nodeConfig.minNodeSize   = cluster.minNodeSize   || 1;
-    nodeConfig.maxNodeSize   = cluster.maxNodeSize   || 3;
-    nodeConfig.onAutoScaling = cluster.onAutoScaling || 'true';
+    nodeConfig.minNodeSize   = firstNodeGroup.minNodeSize   || cluster.minNodeSize   || 1;
+    nodeConfig.maxNodeSize   = firstNodeGroup.maxNodeSize   || cluster.maxNodeSize   || 3;
+    nodeConfig.onAutoScaling = firstNodeGroup.onAutoScaling || cluster.onAutoScaling || 'true';
     nodeConfig.version       = cluster.version       || '';
     nodeGroupRequestFromSpecList.push(nodeConfig);
 

--- a/index.js
+++ b/index.js
@@ -7581,7 +7581,7 @@ function createK8sCluster() {
           .then(imageDesignationNeeded => {
             removeSpinnerTask(taskId);
             
-            // K8s 클러스터 동적 생성 요청 바디를 새로운 중첩 구조(nodeGroups)로 빌드
+            // Build K8s cluster dynamic request body with new nested nodeGroups structure
             const k8sClusterReq = {
               name: clusterName,
               nodeGroups: [
@@ -7593,17 +7593,17 @@ function createK8sCluster() {
               ]
             };
             
-            // 버전에 명시되어 있다면 설정
+            // Set version if specified
             if (k8sVersion) {
               k8sClusterReq.version = k8sVersion;
             }
             
-            // rootDisk 설정이 존재한다면 첫 번째 노드그룹 내에 설정 주입
+            // Inject rootDisk settings into the first node group if available
             if (nodeGroup.rootDiskType) {
               k8sClusterReq.nodeGroups[0].rootDiskType = nodeGroup.rootDiskType;
             }
             if (nodeGroup.rootDiskSize) {
-              // Go의 int 타입 바인딩 매칭을 위해 문자열을 숫자로 파싱
+              // Parse string to number to match Go int type binding
               k8sClusterReq.nodeGroups[0].rootDiskSize = parseInt(nodeGroup.rootDiskSize, 10);
             }
 


### PR DESCRIPTION
## Summary

- Adapt to cb-tumblebug K8s model generalization (cloud-barista/cb-tumblebug#2580): restructure cluster creation request body to nested nodeGroups and update response field names.